### PR TITLE
LayzQuotes for CSV Readers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Build
+      run: (cd ../../ && go build -v ./...)
+
+    - name: Test
+      run: (cd ../../ && go test -v ./...)

--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -214,7 +214,7 @@ func partReader(codec string, conf ReaderConfig) (ReaderConstructor, bool, error
 		}, true, nil
 	case "csv":
 		return func(path string, r io.ReadCloser, fn ReaderAckFn) (Reader, error) {
-			return newCSVReader(r, fn, nil)
+			return newCSVReader(r, fn, nil, nil)
 		}, true, nil
 	case "tar":
 		return newTarReader, true, nil
@@ -239,7 +239,7 @@ func partReader(codec string, conf ReaderConfig) (ReaderConstructor, bool, error
 		}
 		byRune := byRunes[0]
 		return func(path string, r io.ReadCloser, fn ReaderAckFn) (Reader, error) {
-			return newCSVReader(r, fn, &byRune)
+			return newCSVReader(r, fn, &byRune, nil)
 		}, true, nil
 	}
 	if strings.HasPrefix(codec, "chunker:") {
@@ -426,11 +426,15 @@ type csvReader struct {
 	pending  int32
 }
 
-func newCSVReader(r io.ReadCloser, ackFn ReaderAckFn, customComma *rune) (Reader, error) {
+func newCSVReader(r io.ReadCloser, ackFn ReaderAckFn, customComma *rune, lazyQuotes *bool) (Reader, error) {
 	scanner := csv.NewReader(r)
 	scanner.ReuseRecord = true
 	if customComma != nil {
 		scanner.Comma = *customComma
+	}
+
+	if lazyQuotes != nil {
+		scanner.LazyQuotes = *lazyQuotes
 	}
 
 	headers, err := scanner.Read()

--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -214,7 +214,7 @@ func partReader(codec string, conf ReaderConfig) (ReaderConstructor, bool, error
 		}, true, nil
 	case "csv":
 		return func(path string, r io.ReadCloser, fn ReaderAckFn) (Reader, error) {
-			return newCSVReader(r, fn, nil, nil)
+			return newCSVReader(r, fn, nil, true)
 		}, true, nil
 	case "tar":
 		return newTarReader, true, nil
@@ -239,7 +239,7 @@ func partReader(codec string, conf ReaderConfig) (ReaderConstructor, bool, error
 		}
 		byRune := byRunes[0]
 		return func(path string, r io.ReadCloser, fn ReaderAckFn) (Reader, error) {
-			return newCSVReader(r, fn, &byRune, nil)
+			return newCSVReader(r, fn, &byRune, true)
 		}, true, nil
 	}
 	if strings.HasPrefix(codec, "chunker:") {
@@ -426,15 +426,21 @@ type csvReader struct {
 	pending  int32
 }
 
-func newCSVReader(r io.ReadCloser, ackFn ReaderAckFn, customComma *rune, lazyQuotes *bool) (Reader, error) {
+func newCSVReader(
+	r io.ReadCloser,
+	ackFn ReaderAckFn,
+	customComma *rune,
+	csvLazyQuotes bool,
+) (Reader,
+	error) {
 	scanner := csv.NewReader(r)
 	scanner.ReuseRecord = true
 	if customComma != nil {
 		scanner.Comma = *customComma
 	}
 
-	if lazyQuotes != nil {
-		scanner.LazyQuotes = *lazyQuotes
+	if csvLazyQuotes {
+		scanner.LazyQuotes = csvLazyQuotes
 	}
 
 	headers, err := scanner.Read()

--- a/internal/codec/reader_test.go
+++ b/internal/codec/reader_test.go
@@ -334,12 +334,16 @@ func TestLinesReader(t *testing.T) {
 }
 
 func TestCSVReader(t *testing.T) {
-	data := []byte("col1,col2,col3\nfoo1,bar1,baz1\nfoo2,bar2,baz2\nfoo3,bar3,baz3")
+	data := []byte(`col1,col2,col3
+foo1,bar 1","baz1"
+foo2,bar 2","baz2"
+foo3,bar 3","baz3"`)
+
 	testReaderSuite(
 		t, "csv", "", data,
-		`{"col1":"foo1","col2":"bar1","col3":"baz1"}`,
-		`{"col1":"foo2","col2":"bar2","col3":"baz2"}`,
-		`{"col1":"foo3","col2":"bar3","col3":"baz3"}`,
+		`{"col1":"foo1","col2":"bar 1\"","col3":"baz1"}`,
+		`{"col1":"foo2","col2":"bar 2\"","col3":"baz2"}`,
+		`{"col1":"foo3","col2":"bar 3\"","col3":"baz3"}`,
 	)
 
 	data = []byte("col1,col2,col3")


### PR DESCRIPTION
# LazyQuotes for CSV Reader (#1038)

## Description

Configures the CSV reader in `benthos` to use the`LazyQoutes` field from the struct `Reader` in the standard library's `encoding/csv` package.

<!--

Yo David:

I updated the tests to test the LazyQuotes settings are being created and used as expected
and they are passing now 🎉. 

I used the backslashes to allow multiline strings like that but if you can try getting it to work 
with escaping with `\"` in a string, it'd be more inline with the patterns used in other tests - 
just couldn't get it working myself without breaking the Reader.

After that, I think we're ready to create the PR..LFG

Hottest collab of 2022.
-->

  
